### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/anjumtest/4aa2ebe0-296c-460e-a33f-e7f759fca480/61a488a7-7bef-4e0e-be32-0ee881899c43/_apis/work/boardbadge/d986e572-e4b4-4648-9d57-b1322109e2fc)](https://dev.azure.com/anjumtest/4aa2ebe0-296c-460e-a33f-e7f759fca480/_boards/board/t/61a488a7-7bef-4e0e-be32-0ee881899c43/Microsoft.RequirementCategory)
 [![GitHub license](https://img.shields.io/github/license/microsoft/Web-Dev-For-Beginners.svg)](https://github.com/microsoft/Web-Dev-For-Beginners/blob/master/LICENSE)
 [![GitHub contributors](https://img.shields.io/github/contributors/microsoft/Web-Dev-For-Beginners.svg)](https://GitHub.com/microsoft/Web-Dev-For-Beginners/graphs/contributors/)
 [![GitHub issues](https://img.shields.io/github/issues/microsoft/Web-Dev-For-Beginners.svg)](https://GitHub.com/microsoft/Web-Dev-For-Beginners/issues/)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/anjumtest/4aa2ebe0-296c-460e-a33f-e7f759fca480/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.